### PR TITLE
Second try at fixing issue #9 after rebasing.

### DIFF
--- a/erddaplogs/logparse.py
+++ b/erddaplogs/logparse.py
@@ -205,11 +205,9 @@ def _get_ip_info(df, ip_info_csv, download_new=True, num_new_ips=60, verbose=Fal
                     else:
                         print(f"New ip identified: {ip}. Sent {count} requests")
                 try:
-                    df_ip = pl.concat((df_ip, pl.DataFrame(resp)))
+                    df_ip = pl.concat((df_ip, pl.DataFrame(resp)), how="diagonal")
                 except (pl.exceptions.SchemaError, pl.exceptions.ShapeError):
                     print(f"Issue fetching data for this ip address {ip}, skipping")
-    df_ip = df_ip.filter(~pl.col("country").is_null())
-    df_ip = df_ip.filter(pl.col("country") != "")
     df_ip.write_csv(ip_info_csv)
     if verbose:
         print(f"We have info on {len(df_ip)} ip address")


### PR DESCRIPTION
Concat also the failed ip-api.com responses so that missing columns will have null values. This way we'll keep the ip information at least for further stats if wanted. Will probably break some plotting functions. They will need checks for not operating on null values where applicable. 