### PR TITLE
Revamp saving of anonymised data

### DIFF
--- a/erddaplogs/plot_functions.py
+++ b/erddaplogs/plot_functions.py
@@ -73,10 +73,10 @@ def _plot_popularity_bar(ax, df, col_name, rows):
     counts = Counter(df[col_name].to_list()).most_common()
     if None in counts[0]:
         counts = counts[1:]
+    names, counts = list(map(list, zip(*counts)))
     df_counts = (
-        pl.DataFrame(counts)[:rows]
+        pl.DataFrame({col_name: names, "counts": counts})[:rows]
         .fill_null("unknown")
-        .rename({"column_0": col_name, "column_1": "counts"})
     )
     ax.barh(
         np.arange(len(df_counts)),

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,8 @@ pandas
 matplotlib
 jupyterlab
 requests
-polars<=0.20.10
+polars>=1.0.0
+numpy<2
 tqdm
 apachelogs
 pyarrow

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests
 pandas
-polars<=0.20.10
+polars>=1.0.0
 pyarrow
 apachelogs
 user_agents

--- a/tests/test_erddap_logs.py
+++ b/tests/test_erddap_logs.py
@@ -31,7 +31,7 @@ def test_anonymized_data():
     for blocked_col in ["user-agent", "lat", "lon", "org", "zip", "city"]:
         assert blocked_col not in parser.anonymized.columns
     assert parser.anonymized['ip'].dtype == pl.Int32
-    assert parser.location.columns == ['countryCode', 'regionName', 'city', 'len']
+    assert parser.location.columns == ['countryCode', 'regionName', 'city', 'total_requests']
 
 
 def test_plots():


### PR DESCRIPTION
With this PR we make several improvements to how anonymized data are stored:

- users can specify a dir to save anonymised data to 
- erddaplogs will only process data from requests that have come in since the last time it was run
- location data stats are combined with stats from previous runs, so we end up with just one file with each location row unique

All of these changes should make it much easier to integrate the anonymised user data into ERDDAP, following discussions in https://github.com/ERDDAP/erddap/discussions/162

Another PR will follow with instructions on how to make these stats available as datasets on ERDDAP

This PR also increases reliablility with timezone flexible datestamp parsing and using the newly released polars v1.0.0