### PR TITLE
fix erddap encoding to utf-8

### DIFF
--- a/example_data/requests.xml
+++ b/example_data/requests.xml
@@ -7,7 +7,7 @@
     <pathRegex>.*</pathRegex>
     <metadataFrom>last</metadataFrom>
     <standardizeWhat>0</standardizeWhat>
-    <charset>ISO-8859-1</charset>
+    <charset>UTF-8</charset>
     <columnSeparator>,</columnSeparator>
     <columnNamesRow>1</columnNamesRow>
     <firstDataRow>2</firstDataRow>


### PR DESCRIPTION
Turns out the fix in #70 was unnecessary, just needed to specify the correct encoding (UTF-8) in the ERDDAP dataset xml